### PR TITLE
Add emscripten support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,7 @@ impl Build {
             .cargo_metadata(false)
             .flag_if_supported("-std=c++17")
             .flag_if_supported("/std:c++17") // MSVC
+            .flag("-fexceptions")
             .cpp(true);
 
         // Common defines

--- a/testcrate/build.rs
+++ b/testcrate/build.rs
@@ -1,5 +1,15 @@
+use std::env;
+
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
-    let artifacts = luau0_src::Build::new().enable_codegen(true).build();
+
+    let target = env::var("TARGET").unwrap();
+
+    let artifacts = if !target.ends_with("emscripten") {
+        luau0_src::Build::new().enable_codegen(true).build()
+    } else {
+        // llvm generates bytecode for the codegen module which is not supported on wasm
+        luau0_src::Build::new().enable_codegen(false).build()
+    };
     artifacts.print_cargo_metadata();
 }

--- a/testcrate/src/lib.rs
+++ b/testcrate/src/lib.rs
@@ -38,8 +38,11 @@ extern "C" {
         env: c_int,
     ) -> c_int;
 
+    #[cfg(not(target_os = "emscripten"))]
     pub fn luau_codegen_supported() -> c_int;
+    #[cfg(not(target_os = "emscripten"))]
     pub fn luau_codegen_create(state: *mut c_void);
+    #[cfg(not(target_os = "emscripten"))]
     pub fn luau_codegen_compile(state: *mut c_void, idx: c_int);
 }
 
@@ -54,6 +57,7 @@ fn luau_works() {
         let state = luaL_newstate();
         assert!(state != ptr::null_mut());
 
+        #[cfg(not(target_os = "emscripten"))]
         // Enable JIT if supported
         if luau_codegen_supported() != 0 {
             luau_codegen_create(state);
@@ -82,6 +86,7 @@ fn luau_works() {
         assert_eq!(result, 0);
         free(bytecode.cast());
 
+        #[cfg(not(target_os = "emscripten"))]
         // Compile the function (JIT, if supported)
         if luau_codegen_supported() != 0 {
             luau_codegen_compile(state, -1);


### PR DESCRIPTION
This PR adds support for the emscripten target.

The `CodeGen` module cannot be compiled with wasm because it's missing some features LLVM generates. Currently there is no indicator that CodeGen isn't compatible with wasm, when trying the compilation just fails with a compile error (`error in backend: llvm.clear_cache is not supported on wasm` + a bunch of warnings after that).